### PR TITLE
Handle invalid repository url

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,7 +45,7 @@ function open(name) {
 				const url = githubUrlFromGit(pkg.repository.url) || pkg.repository.url;
 
 				if (!urlRegex().test(url)) {
-					console.error('Invalid repository URL, opening homepage');
+					console.error('The repository URL in package.json is invalid. Open an issue on the project or create a PR with a fix. Opening homepage instead.');
 					return opn(pkg.homepage, {wait: false});
 				}
 

--- a/cli.js
+++ b/cli.js
@@ -5,6 +5,7 @@ const readPkgUp = require('read-pkg-up');
 const opn = require('opn');
 const packageJson = require('package-json');
 const githubUrlFromGit = require('github-url-from-git');
+const urlRegex = require('url-regex');
 
 const cli = meow(`
 	Usage
@@ -41,9 +42,9 @@ function open(name) {
 	if (cli.flags.github) {
 		return packageJson(name, {fullMetadata: true}).then(pkg => {
 			if (pkg.repository) {
-				const url = pkg.repository.url.startsWith('git') ? githubUrlFromGit(pkg.repository.url) : `${pkg.repository.url}`;
+				const url = githubUrlFromGit(pkg.repository.url) || pkg.repository.url;
 
-				if (!url) {
+				if (!urlRegex().test(url)) {
 					console.log('Invalid repository URL, opening homepage');
 					return opn(pkg.homepage, {wait: false});
 				}

--- a/cli.js
+++ b/cli.js
@@ -45,7 +45,7 @@ function open(name) {
 				const url = githubUrlFromGit(pkg.repository.url) || pkg.repository.url;
 
 				if (!urlRegex().test(url)) {
-					console.log('Invalid repository URL, opening homepage');
+					console.error('Invalid repository URL, opening homepage');
 					return opn(pkg.homepage, {wait: false});
 				}
 

--- a/cli.js
+++ b/cli.js
@@ -41,7 +41,13 @@ function open(name) {
 	if (cli.flags.github) {
 		return packageJson(name, {fullMetadata: true}).then(pkg => {
 			if (pkg.repository) {
-				const url = githubUrlFromGit(pkg.repository.url);
+				const url = pkg.repository.url.startsWith('git') ? githubUrlFromGit(pkg.repository.url) : `${pkg.repository.url}`;
+
+				if (!url) {
+					console.log('Invalid repository URL, opening homepage');
+					return opn(pkg.homepage, {wait: false});
+				}
+
 				return opn(url, {wait: false});
 			}
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
 		"meow": "^3.7.0",
 		"opn": "^5.0.0",
 		"package-json": "^4.0.1",
-		"read-pkg-up": "^2.0.0"
+		"read-pkg-up": "^2.0.0",
+		"url-regex": "^4.1.1"
 	},
 	"devDependencies": {
 		"ava": "*",


### PR DESCRIPTION
Fixes #5 
tested with 
```
{
    "name": "chalk",
    "repository": {
        "type": "git",
        "url": "git+https://github.com/chalk/chalk.git"
    },
    "homepage": "https://github.com/chalk/chalk#readme"
};
```

```
{
    "name": "chalk",
    "repository": {
        "type": "git",
        "url": "https://github.com/chalk/chalk"
    },
    "homepage": "https://github.com/chalk/chalk#readme"
};
```

```
{
    "name": "chalk",
    "repository": {
        "type": "git",
        "url": "/chalk/chalk"
    },
    "homepage": "https://github.com/chalk/chalk#readme"
};
```