### PR TITLE
Move to ESM, target Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 18, 20]
+        node-version:
+          - 20
+          - 18
+          - 16
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,11 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version:
-          - 14
-          - 12
-          - 10
-          - 8
+        node-version: [16, 18, 20]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-'use strict';
-const meow = require('meow');
-const readPkgUp = require('read-pkg-up');
-const open = require('open');
-const packageJson = require('package-json');
-const githubUrlFromGit = require('github-url-from-git');
-const isUrl = require('is-url-superb');
+import process from 'node:process';
+import meow from 'meow';
+import {readPackageUp} from 'read-pkg-up';
+import open from 'open';
+import packageJson from 'package-json';
+import githubUrlFromGit from 'github-url-from-git';
+import isUrl from 'is-url-superb';
 
 const cli = meow(`
 	Usage
@@ -13,27 +13,28 @@ const cli = meow(`
 	  $ nh [name]
 
 	Options
-	  --github -g  Open the GitHub repo of the package
-	  --yarn -y    Open the Yarn homepage of the package
+	  --github  -g  Open the GitHub repo of the package
+	  --yarn    -y  Open the Yarn homepage of the package
 
 	Examples
 	  $ npm-home
 	  $ npm-home chalk -g
 `, {
+	importMeta: import.meta,
 	flags: {
 		github: {
 			type: 'boolean',
-			alias: 'g'
+			shortFlag: 'g',
 		},
 		yarn: {
 			type: 'boolean',
-			alias: 'y'
-		}
-	}
+			shortFlag: 'y',
+		},
+	},
 });
 
 const openNpm = async name => open(`https://www.npmjs.com/package/${name}`);
-const openYarn = async name => open(`https://yarn.pm/${name}`);
+const openYarn = async name => open(`https://yarnpkg.com/package/?name=${name}`);
 
 const openNpmOrYarn = cli.flags.yarn ? openYarn : openNpm;
 
@@ -81,17 +82,15 @@ const openPackage = async name => {
 	await openNpmOrYarn(name);
 };
 
-(async () => {
-	if (cli.input.length > 0) {
-		await openPackage(cli.input[0]);
-	} else {
-		const result = readPkgUp.sync();
+if (cli.input.length > 0) {
+	await openPackage(cli.input[0]);
+} else {
+	const result = await readPackageUp();
 
-		if (!result) {
-			console.error('You\'re not in an npm package');
-			process.exit(1);
-		}
-
-		await openPackage(result.package.name);
+	if (!result) {
+		console.error('You\'re not in an npm package');
+		process.exit(1);
 	}
-})();
+
+	await openPackage(result.packageJson.name);
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
 		"npm-home": "cli.js",
 		"nh": "cli.js"
 	},
+	"type": "module",
 	"engines": {
-		"node": ">=8"
+		"node": ">=16"
 	},
 	"scripts": {
 		"test": "xo && ava"
@@ -41,15 +42,15 @@
 	],
 	"dependencies": {
 		"github-url-from-git": "^1.5.0",
-		"is-url-superb": "^3.0.0",
-		"meow": "^5.0.0",
-		"open": "^6.3.0",
-		"package-json": "^6.3.0",
-		"read-pkg-up": "^6.0.0"
+		"is-url-superb": "^6.1.0",
+		"meow": "^12.1.0",
+		"open": "^9.1.0",
+		"package-json": "^8.1.1",
+		"read-pkg-up": "^10.0.1"
 	},
 	"devDependencies": {
-		"ava": "^1.4.1",
-		"execa": "^1.0.0",
-		"xo": "^0.24.0"
+		"ava": "^5.3.1",
+		"execa": "^8.0.1",
+		"xo": "^0.56.0"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -2,17 +2,15 @@
 
 > Open the npm page, Yarn page, or GitHub repo of a package
 
-
 ## Install
 
+```sh
+npm install --global npm-home
 ```
-$ npm install --global npm-home
-```
-
 
 ## Usage
 
-```
+```sh
 $ npm-home --help
 
   Usage
@@ -21,18 +19,16 @@ $ npm-home --help
 
   Options
     --github -g  Open the GitHub repo of the package
-    --yarn -y    Open the Yarn homepage of the package
+    --yarn   -y  Open the Yarn homepage of the package
 
   Examples
     $ npm-home
     $ npm-home chalk -g
 ```
 
-
 ## Related
 
 - [gh-home](https://github.com/sindresorhus/gh-home) - Open the GitHub page of the given or current directory repo
-
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,20 @@
 import test from 'ava';
-import execa from 'execa';
+import {execa} from 'execa';
 
-test('main', async t => {
-	await t.notThrowsAsync(execa('./cli.js'));
+const testCli = test.macro(async (t, args = []) => {
+	await t.notThrowsAsync(execa('./cli.js', args));
 });
+
+test('main', testCli);
+
+test('named package', testCli, ['chalk']);
+
+for (const flag of ['--github', '-g']) {
+	test(`github: ${flag}`, testCli, [flag]);
+	test(`named package - github: ${flag}`, testCli, [flag, 'chalk']);
+}
+
+for (const flag of ['--yarn', '-y']) {
+	test(`yarn: ${flag}`, testCli, [flag]);
+	test(`named package - yarn: ${flag}`, testCli, [flag, 'chalk']);
+}


### PR DESCRIPTION
Updates:
* Converts to ESM
* Targets Node.js 16
* Uses `https://yarnpkg.com/package/?name=${name}` instead of `https://yarn.pm/${name}`
* Updates CI matrix
* Updates dependencies
* Adds extra tests

Updating `open` also allows `npm-home` to work on WSL. The current version is unable to open any links, at least on my machine.