### PR TITLE
Support multiple inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"is-url-superb": "^6.1.0",
 		"meow": "^12.1.0",
 		"open": "^9.1.0",
+		"p-map": "^6.0.0",
 		"package-json": "^8.1.1",
 		"read-pkg-up": "^10.0.1"
 	},

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ npm install --global npm-home
 $ npm-home --help
 
   Usage
-    $ npm-home [name]
-    $ nh [name]
+    $ npm-home [name …]
+    $ nh [name …]
 
   Options
     --github -g  Open the GitHub repo of the package
@@ -24,6 +24,7 @@ $ npm-home --help
   Examples
     $ npm-home
     $ npm-home chalk -g
+    $ npm-home execa ava -y
 ```
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -1,6 +1,9 @@
 import test from 'ava';
 import {execa} from 'execa';
 
+// Tests only checks that opening doesn't return an error, not that the correct page was opened.
+// These have to be manually verified.
+
 const testCli = test.macro(async (t, args = []) => {
 	await t.notThrowsAsync(execa('./cli.js', args));
 });

--- a/test.js
+++ b/test.js
@@ -6,15 +6,17 @@ const testCli = test.macro(async (t, args = []) => {
 });
 
 test('main', testCli);
-
 test('named package', testCli, ['chalk']);
+test('multiple packages', testCli, ['execa', 'ava']);
 
 for (const flag of ['--github', '-g']) {
 	test(`github: ${flag}`, testCli, [flag]);
 	test(`named package - github: ${flag}`, testCli, [flag, 'chalk']);
+	test(`multiple packages - github: ${flag}`, testCli, [flag, 'execa', 'ava']);
 }
 
 for (const flag of ['--yarn', '-y']) {
 	test(`yarn: ${flag}`, testCli, [flag]);
 	test(`named package - yarn: ${flag}`, testCli, [flag, 'chalk']);
+	test(`multiple packages - yarn: ${flag}`, testCli, [flag, 'execa', 'ava']);
 }


### PR DESCRIPTION
Closes #15.

Adds support for multiple inputs to `npm-home`:

```sh
> npm-home execa ava ...
```

Uses `p-map` to limit concurrency of `open` requests (currently set to `5`).