### PR TITLE
Handle package not found error when opening GitHub URLs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -6,6 +6,7 @@ import open from 'open';
 import packageJson, {PackageNotFoundError} from 'package-json';
 import githubUrlFromGit from 'github-url-from-git';
 import isUrl from 'is-url-superb';
+import logSymbols from 'log-symbols';
 import pMap from 'p-map';
 
 const cli = meow(`
@@ -56,9 +57,9 @@ const openGitHub = async name => {
 			url = repository.url;
 
 			if (isUrl(url) && /^https?:\/\//.test(url)) {
-				console.error(`The \`repository\` field in package.json should point to a Git repo and not a website. Please open an issue or pull request on \`${name}\`.`);
+				console.error(`${logSymbols.error} The \`repository\` field in package.json should point to a Git repo and not a website. Please open an issue or pull request on \`${name}\`.`);
 			} else {
-				console.error(`The \`repository\` field in package.json is invalid. Please open an issue or pull request on \`${name}\`. Using the \`homepage\` field instead.`);
+				console.error(`${logSymbols.error} The \`repository\` field in package.json is invalid. Please open an issue or pull request on \`${name}\`. Using the \`homepage\` field instead.`);
 
 				url = packageData.homepage;
 			}
@@ -67,13 +68,17 @@ const openGitHub = async name => {
 		await open(url);
 	} catch (error) {
 		if (error.code === 'ENOTFOUND') {
-			console.error('No network connection detected!');
-			process.exit(1);
+			console.error(`${logSymbols.error} No network connection detected!`);
+
+			process.exitCode = 1;
+			return;
 		}
 
 		if (error instanceof PackageNotFoundError) {
-			console.error(`Package \`${name}\` doesn't exist!`);
-			process.exit(1); // TODO: this is 'fail-fast' -> if invoked with multiple names, later ones won't open
+			console.error(`${logSymbols.error} ${name} - package not found!`);
+
+			process.exitCode = 1;
+			return;
 		}
 
 		throw error;

--- a/cli.js
+++ b/cli.js
@@ -3,15 +3,15 @@ import process from 'node:process';
 import meow from 'meow';
 import {readPackageUp} from 'read-pkg-up';
 import open from 'open';
-import packageJson from 'package-json';
+import packageJson, {PackageNotFoundError} from 'package-json';
 import githubUrlFromGit from 'github-url-from-git';
 import isUrl from 'is-url-superb';
 import pMap from 'p-map';
 
 const cli = meow(`
 	Usage
-	  $ npm-home [name …]
-	  $ nh [name …]
+	  $ npm-home [name] […]
+	  $ nh [name] […]
 
 	Options
 	  --github  -g  Open the GitHub repo of the package
@@ -69,6 +69,11 @@ const openGitHub = async name => {
 		if (error.code === 'ENOTFOUND') {
 			console.error('No network connection detected!');
 			process.exit(1);
+		}
+
+		if (error instanceof PackageNotFoundError) {
+			console.error(`Package \`${name}\` doesn't exist!`);
+			process.exit(1); // TODO: this is 'fail-fast' -> if invoked with multiple names, later ones won't open
 		}
 
 		throw error;

--- a/cli.js
+++ b/cli.js
@@ -69,14 +69,12 @@ const openGitHub = async name => {
 	} catch (error) {
 		if (error.code === 'ENOTFOUND') {
 			console.error(`${logSymbols.error} No network connection detected!`);
-
 			process.exitCode = 1;
 			return;
 		}
 
 		if (error instanceof PackageNotFoundError) {
 			console.error(`${logSymbols.error} ${name} - package not found!`);
-
 			process.exitCode = 1;
 			return;
 		}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	"dependencies": {
 		"github-url-from-git": "^1.5.0",
 		"is-url-superb": "^6.1.0",
+		"log-symbols": "^5.1.0",
 		"meow": "^12.1.0",
 		"open": "^9.1.0",
 		"p-map": "^6.0.0",

--- a/readme.md
+++ b/readme.md
@@ -14,8 +14,8 @@ npm install --global npm-home
 $ npm-home --help
 
   Usage
-    $ npm-home [name …]
-    $ nh [name …]
+    $ npm-home [name] […]
+    $ nh [name] […]
 
   Options
     --github -g  Open the GitHub repo of the package

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ for (const flag of ['--github', '-g']) {
 	test(`github - does not error on missing package: ${flag}`, async t => {
 		// https://github.com/npm/validate-npm-package-name#naming-rules
 		const {stderr} = await t.throwsAsync(execa('./cli.js', [flag, '~invalid~']));
-		t.is(stderr, 'Package `~invalid~` doesn\'t exist!');
+		t.is(stderr, '✖ ~invalid~ - package not found!');
 	});
 }
 

--- a/test.js
+++ b/test.js
@@ -29,4 +29,3 @@ for (const flag of ['--yarn', '-y']) {
 	test(`named package - yarn: ${flag}`, testCli, [flag, 'chalk']);
 	test(`multiple packages - yarn: ${flag}`, testCli, [flag, 'execa', 'ava']);
 }
-

--- a/test.js
+++ b/test.js
@@ -16,6 +16,12 @@ for (const flag of ['--github', '-g']) {
 	test(`github: ${flag}`, testCli, [flag]);
 	test(`named package - github: ${flag}`, testCli, [flag, 'chalk']);
 	test(`multiple packages - github: ${flag}`, testCli, [flag, 'execa', 'ava']);
+
+	test(`github - does not error on missing package: ${flag}`, async t => {
+		// https://github.com/npm/validate-npm-package-name#naming-rules
+		const {stderr} = await t.throwsAsync(execa('./cli.js', [flag, '~invalid~']));
+		t.is(stderr, 'Package `~invalid~` doesn\'t exist!');
+	});
 }
 
 for (const flag of ['--yarn', '-y']) {
@@ -23,3 +29,4 @@ for (const flag of ['--yarn', '-y']) {
 	test(`named package - yarn: ${flag}`, testCli, [flag, 'chalk']);
 	test(`multiple packages - yarn: ${flag}`, testCli, [flag, 'execa', 'ava']);
 }
+


### PR DESCRIPTION
When opening a non-existent NPM or Yarn package, `npm-home` will open a 404 page. When trying to open the same "package" on GitHub, `npm-home` throws a long error:

```
$ npm-home -g '~invalid~'
file:///.../npm-home/node_modules/package-json/index.js:72
			throw new PackageNotFoundError(packageName);
			      ^

PackageNotFoundError: Package `~invalid~` could not be found
    at packageJson (file:///.../npm-home/node_modules/package-json/index.js:72:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async openGitHub (file:///.../npm-home/cli.js:45:23)
    at async pMap.concurrency (file:///.../npm-home/cli.js:80:3)
    at async file:///.../npm-home/node_modules/p-map/index.js:139:20
```

This is because `package-json` throws:

https://github.com/sindresorhus/npm-home/blob/7e2e51cbfc50a6aa66091d7a0449117eb77c1c20/cli.js#L45-L46

This PR catches the `PackageNotFoundError` and logs a nicer message:

```
$ npm-home -g '~invalid~'
Package `~invalid~` doesn't exist!
```

The error message could likely be improved.