### PR TITLE
Use `repo-url-from-package`, update deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 21
           - 20
           - 18

--- a/cli.js
+++ b/cli.js
@@ -50,18 +50,23 @@ const openGitHub = async name => {
 			return;
 		}
 
-		const {url = packageData.homepage, warnings} = repoUrlFromPackage(packageData);
+		const {url, warnings} = repoUrlFromPackage(packageData);
 
 		for (const warning of warnings) {
 			console.error(`${logSymbols.error} ${warning}`);
 		}
 
-		if (!url) {
-			console.error(`${logSymbols.error} No \`homepage\` field found in package.json.`);
+		if (url) {
+			await open(url);
 			return;
 		}
 
-		await open(url);
+		if (packageData.homepage) {
+			console.log(`${logSymbols.warning} Falling back to \`homepage\` field.`);
+			await open(packageData.homepage);
+		} else {
+			console.error(`${logSymbols.error} No \`repository\` or \`homepage\` field found in package.json. Please open an issue or pull request on ${name}`);
+		}
 	} catch (error) {
 		if (error.code === 'ENOTFOUND') {
 			console.error(`${logSymbols.error} No network connection detected!`);

--- a/cli.js
+++ b/cli.js
@@ -53,7 +53,7 @@ const openGitHub = async name => {
 		const {url = packageData.homepage, warnings} = repoUrlFromPackage(packageData);
 
 		for (const warning of warnings) {
-			console.error(`${logSymbols.warning} ${warning}`);
+			console.error(`${logSymbols.error} ${warning}`);
 		}
 
 		if (!url) {

--- a/cli.js
+++ b/cli.js
@@ -4,8 +4,7 @@ import meow from 'meow';
 import {readPackageUp} from 'read-package-up';
 import open from 'open';
 import packageJson, {PackageNotFoundError} from 'package-json';
-import githubUrlFromGit from 'github-url-from-git';
-import isUrl from 'is-url-superb';
+import repoUrlFromPackage from 'repo-url-from-package';
 import logSymbols from 'log-symbols';
 import pMap from 'p-map';
 
@@ -51,18 +50,15 @@ const openGitHub = async name => {
 			return;
 		}
 
-		let url = githubUrlFromGit(repository.url);
+		const {url = packageData.homepage, warnings} = repoUrlFromPackage(packageData);
+
+		for (const warning of warnings) {
+			console.error(`${logSymbols.warning} ${warning}`);
+		}
 
 		if (!url) {
-			url = repository.url;
-
-			if (isUrl(url) && /^https?:\/\//.test(url)) {
-				console.error(`${logSymbols.error} The \`repository\` field in package.json should point to a Git repo and not a website. Please open an issue or pull request on \`${name}\`.`);
-			} else {
-				console.error(`${logSymbols.error} The \`repository\` field in package.json is invalid. Please open an issue or pull request on \`${name}\`. Using the \`homepage\` field instead.`);
-
-				url = packageData.homepage;
-			}
+			console.error(`${logSymbols.error} No \`homepage\` field found in package.json.`);
+			return;
 		}
 
 		await open(url);

--- a/package.json
+++ b/package.json
@@ -42,18 +42,17 @@
 		"yarn"
 	],
 	"dependencies": {
-		"github-url-from-git": "^1.5.0",
-		"is-url-superb": "^6.1.0",
 		"log-symbols": "^6.0.0",
 		"meow": "^13.2.0",
-		"open": "^10.0.3",
-		"p-map": "^7.0.1",
-		"package-json": "^10.0.0",
-		"read-package-up": "^11.0.0"
+		"open": "^10.1.0",
+		"p-map": "^7.0.2",
+		"package-json": "^10.0.1",
+		"read-package-up": "^11.0.0",
+		"repo-url-from-package": "^0.1.0"
 	},
 	"devDependencies": {
-		"ava": "^6.1.1",
-		"execa": "^8.0.1",
-		"xo": "^0.57.0"
+		"ava": "^6.1.3",
+		"execa": "^9.3.0",
+		"xo": "^0.59.2"
 	}
 }

--- a/test.js
+++ b/test.js
@@ -22,6 +22,11 @@ for (const flag of ['--github', '-g']) {
 		const {stderr} = await t.throwsAsync(execa('./cli.js', [flag, '~invalid~']));
 		t.is(stderr, '✖ ~invalid~ - package not found!');
 	});
+
+	test(`github - invalid repository warning: ${flag}`, async t => {
+		const {stderr} = await execa('./cli.js', [flag, 'babel-preset-minify']); // From #5
+		t.is(stderr, '✖ The `repository` field in package.json should point to a Git repo and not a website. Please open an issue or pull request on `babel-preset-minify`.');
+	});
 }
 
 for (const flag of ['--yarn', '-y']) {


### PR DESCRIPTION
Closes #19.

Uses [`repo-url-from-package`](https://github.com/sindresorhus/repo-url-from-package) to parse GitHub URLs, and adds an additional warning when the `package.json` `"homepage"` field fallback isn't found.

Also adds Node.js 22 to the CI matrix.